### PR TITLE
Fix always using the latest JDK

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'java-library'
+    id 'idea'
     id 'maven-publish'
     id 'net.minecraftforge.licenser' version '1.0.1'
     id 'net.minecraftforge.gradleutils' version '2.3.6'
@@ -117,5 +118,13 @@ publishing {
     }
     repositories {
         maven gradleutils.publishingForgeMaven
+    }
+}
+
+idea {
+    module {
+        // IntelliJ IDEA does not do this by itself anymore...
+        downloadJavadoc = true
+        downloadSources = true
     }
 }

--- a/src/main/java/net/minecraftforge/jver/Disco.java
+++ b/src/main/java/net/minecraftforge/jver/Disco.java
@@ -123,7 +123,7 @@ public class Disco {
 
         List<Package> ret = new ArrayList<>();
         for (Package pkg : jdks) {
-            if (version != -1 && pkg.jdk_version < version)
+            if (version != -1 && pkg.jdk_version != version)
                 continue;
             if (os != null && pkg.os() != os)
                 continue;


### PR DESCRIPTION
Small logic error that makes it so the latest JDK is always used. This fixes that.