### PR TITLE
Ignore additional IDE files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,10 @@
 /**/build/
 /repo/
 /cache/
+
+# Tool Output - Jonathan uses the run directory
+/run/
+/output/
+
+# Jonathan's IntelliJ Fuckery
+/.idea/


### PR DESCRIPTION
Additional `.gitignore` entries for IntelliJ settings and outputs.