### PR TITLE
Add offline mode toggle to prevent downloads

### DIFF
--- a/src/main/java/net/minecraftforge/java_version/DiscoLocator.java
+++ b/src/main/java/net/minecraftforge/java_version/DiscoLocator.java
@@ -31,9 +31,15 @@ import net.minecraftforge.java_version.util.OS;
  */
 public class DiscoLocator extends JavaHomeLocator {
     private final File cache;
+    private final boolean offline;
 
     public DiscoLocator(File cache) {
+        this(cache, false);
+    }
+
+    public DiscoLocator(File cache, boolean offline) {
         this.cache = cache;
+        this.offline = offline;
     }
 
     @Override
@@ -77,7 +83,7 @@ public class DiscoLocator extends JavaHomeLocator {
     @Override
     public IJavaInstall provision(int version) {
         log("Locators failed to find any suitable installs, attempting Disco download");
-        Disco disco = new Disco(cache) { // TODO: [DISCO][Logging] Add a proper logging handler sometime
+        Disco disco = new Disco(cache, offline) { // TODO: [DISCO][Logging] Add a proper logging handler sometime
             @Override
             protected void debug(String message) {
                 DiscoLocator.this.log(message);

--- a/src/main/java/net/minecraftforge/java_version/Main.java
+++ b/src/main/java/net/minecraftforge/java_version/Main.java
@@ -11,6 +11,8 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+
+import joptsimple.AbstractOptionSpec;
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
 import joptsimple.OptionSpec;
@@ -30,6 +32,9 @@ public class Main {
                 "Directory to store data needed for this program")
                 .withRequiredArg().ofType(File.class).defaultsTo(new File("cache"));
 
+        AbstractOptionSpec<Void> offlineO = parser.accepts("offline",
+                "Do not attempt to download any JDKs, only use the cache");
+
         OptionSpec<Integer> versionO = parser.accepts("version",
                 "Major version of java to try and locate")
                 .withOptionalArg().ofType(Integer.class);
@@ -43,7 +48,7 @@ public class Main {
             return;
         }
         File cache = options.valueOf(cacheO);
-        DiscoLocator disco = new DiscoLocator(cache);
+        DiscoLocator disco = new DiscoLocator(cache, options.has(offlineO));
 
         List<IJavaLocator> locators = new ArrayList<>();
         locators.add(new JavaHomeLocator());

--- a/src/main/java/net/minecraftforge/java_version/api/IJavaLocator.java
+++ b/src/main/java/net/minecraftforge/java_version/api/IJavaLocator.java
@@ -64,4 +64,8 @@ public interface IJavaLocator {
     static IJavaLocator disco(File cache) {
         return new DiscoLocator(cache);
     }
+
+    static IJavaLocator disco(File cache, boolean offline) {
+        return new DiscoLocator(cache, offline);
+    }
 }


### PR DESCRIPTION
Name entails. Adds an `--offline` flag for main function and a `boolean offline` parameter to `IJavaLocator#disco` to enable offline mode, which prevents any downloads from occuring.